### PR TITLE
express details page: add style to nav (2)

### DIFF
--- a/assets/cms/scss/_base.scss
+++ b/assets/cms/scss/_base.scss
@@ -100,3 +100,4 @@
 @import './utilities';
 @import './popover';
 @import './nav';
+@import './nav-sidebar';

--- a/assets/cms/scss/_nav-sidebar.scss
+++ b/assets/cms/scss/_nav-sidebar.scss
@@ -1,0 +1,43 @@
+div.ccm-ui {
+  .nav {
+    &.nav-sidebar {
+      @include border-radius($list-group-border-radius);
+
+      .nav-item {
+        border: $list-group-border-width solid $list-group-border-color;
+
+        &:first-child {
+          @include border-top-radius(inherit);
+        }
+
+        &:last-child {
+          @include border-bottom-radius(inherit);
+        }
+
+        + .nav-item {
+          border-top-width: 0;
+        }
+
+        a {
+          &:hover {
+            background-color: $gray-100;
+          }
+
+          &.active {
+            position: relative;
+
+            &::before {
+              background-color: $blue;
+              bottom: 0;
+              content: '';
+              left: 0;
+              position: absolute;
+              top: 0;
+              width: 2px;
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This contains the same as #245, but the code is placed in a separate file under a specific class name `nav-sidebar`.
In this case, the class should be added to the page containing the nav.

![Untitled-1](https://user-images.githubusercontent.com/7886999/186347481-56cca325-77de-4c2d-bd8d-e8e33e696cd3.jpg)

