### PR TITLE
Avoid fancytree deprecated methods

### DIFF
--- a/assets/cms/js/sitemap/sitemap-selector.js
+++ b/assets/cms/js/sitemap/sitemap-selector.js
@@ -35,13 +35,13 @@
                 if (options.selected) {
                     if (options.mode == 'multiple') {
                         $.each(options.selected, function(i, cID) {
-                            var node = my.$element.find('.ccm-sitemap-tree').fancytree('getTree').getNodeByKey(String(cID))
+                            var node = $.ui.fancytree.getTree(my.$element.find('.ccm-sitemap-tree')).getNodeByKey(String(cID))
                             if (node) {
                                 node.setSelected(true)
                             }
                         })
                     } else {
-                        var tree = my.$element.find('.ccm-sitemap-tree').fancytree('getTree')
+                        var tree = $.ui.fancytree.getTree(my.$element.find('.ccm-sitemap-tree'))
                         var node = tree.getNodeByKey(String(options.selected))
                         if (node) {
                             node.setSelected(true)

--- a/assets/cms/js/sitemap/sitemap.js
+++ b/assets/cms/js/sitemap/sitemap.js
@@ -47,7 +47,7 @@
 
         getTree: function() {
             var my = this
-            return my.$sitemap.fancytree('getTree')
+            return $.ui.fancytree.getTree(my.$sitemap)
         },
 
         setupSiteTreeSelector: function(tree) {
@@ -340,10 +340,10 @@
             }
             ConcreteEvent.unsubscribe('SitemapDeleteRequestComplete.sitemap')
             ConcreteEvent.subscribe('SitemapDeleteRequestComplete.sitemap', function(e) {
-                var node = my.$sitemap.fancytree('getActiveNode')
+                var node = $.ui.fancytree.getTree($(my.$sitemap)).getActiveNode()
                 var parent = node.parent
                 my.reloadNode(parent)
-                $(my.$sitemap).fancytree('getTree').visit(function(node) {
+                $.ui.fancytree.getTree($(my.$sitemap)).visit(function(node) {
                     // update the trash node when a page is deleted
                     if (node.data.isTrash) {
                         var isTrashNodeExpanded = node.expanded
@@ -456,7 +456,7 @@
             if (pg.length) {
                 pg.find('a:not([disabled])').unbind('click').on('click', function() {
                     var href = $(this).attr('href')
-                    var root = my.$sitemap.fancytree('getRootNode')
+                    var root = $.ui.fancytree.getTree(my.$sitemap).getRootNode()
                     jQuery.fn.dialog.showLoader()
                     $.ajax({
                         dataType: 'json',
@@ -482,7 +482,7 @@
 
             (my.options.onDisplaySingleLevel || $.noop).call(this, node)
 
-            var root = my.$sitemap.fancytree('getRootNode')
+            var root = $.ui.fancytree.getTree(my.$sitemap).getRootNode()
             // my.$sitemap.fancytree('option', 'minExpandLevel', minExpandLevel);
             var ajaxData = $.extend({
                 dataType: 'json',

--- a/assets/cms/js/tree.js
+++ b/assets/cms/js/tree.js
@@ -155,7 +155,7 @@ ConcreteTree.prototype = {
                 if (options.removeNodesByKey.length) {
                     for (var i = 0; i < options.removeNodesByKey.length; i++) {
                         var nodeID = options.removeNodesByKey[i]
-                        var node = $tree.fancytree('getTree').getNodeByKey(String(nodeID))
+                        var node = $.ui.fancytree.getTree($tree).getNodeByKey(String(nodeID))
                         if (node) {
                             node.remove()
                         }
@@ -168,7 +168,7 @@ ConcreteTree.prototype = {
 
                 var selectedNodes
                 if (options.chooseNodeInForm) {
-                    selectedNodes = $tree.fancytree('getTree')
+                    selectedNodes = $.ui.fancytree.getTree($tree)
                     selectedNodes = selectedNodes.getSelectedNodes()
                     if (selectedNodes.length) {
                         var keys = $.map(selectedNodes, function (node) {
@@ -332,7 +332,7 @@ ConcreteTree.prototype = {
                     ConcreteAlert.dialog(ccmi18n.error, r.errors.join('<br>'))
                 } else {
                     jQuery.fn.dialog.closeTop()
-                    var node = $tree.fancytree('getTree').getNodeByKey(String(r.treeNodeParentID))
+                    var node = $.ui.fancytree.getTree($tree).getNodeByKey(String(r.treeNodeParentID))
                     jQuery.fn.dialog.showLoader()
                     my.reloadNode(node, function () {
                         jQuery.fn.dialog.hideLoader()
@@ -411,23 +411,23 @@ ConcreteTree.setupTreeEvents = function (my) {
         var node
         if (nodes.length) {
             for (var i = 0; i < nodes.length; i++) {
-                node = $tree.fancytree('getTree').getNodeByKey(String(nodes[i].treeNodeParentID))
+                node = $.ui.fancytree.getTree($tree).getNodeByKey(String(nodes[i].treeNodeParentID))
                 node.addChildren(nodes)
             }
         } else {
-            node = $tree.fancytree('getTree').getNodeByKey(String(nodes.treeNodeParentID))
+            node = $.ui.fancytree.getTree($tree).getNodeByKey(String(nodes.treeNodeParentID))
             node.addChildren(nodes)
         }
     })
     ConcreteEvent.subscribe('ConcreteTreeUpdateTreeNode.concreteTree', function (e, r) {
         var $tree = $('[data-tree=' + my.options.treeID + ']')
-        var node = $tree.fancytree('getTree').getNodeByKey(String(r.node.key))
+        var node = $.ui.fancytree.getTree($tree).getNodeByKey(String(r.node.key))
         node.fromDict(r.node)
         node.render()
     })
     ConcreteEvent.subscribe('ConcreteTreeDeleteTreeNode.concreteTree', function (e, r) {
         var $tree = $('[data-tree=' + my.options.treeID + ']')
-        var node = $tree.fancytree('getTree').getNodeByKey(String(r.node.treeNodeID))
+        var node = $.ui.fancytree.getTree($tree).getNodeByKey(String(r.node.treeNodeID))
         node.remove()
     })
 }


### PR DESCRIPTION
When using sitemap-related stuff, we have these warnings in the browser developers console:

```
$().fancytree('getActiveNode') is deprecated (see https://wwwendt.de/tech/fancytree/doc/jsdoc/Fancytree_Widget.html
```

Let's fix these warnings.