### PR TITLE
Let users display Concrete dialogs that contains unsafe data

### DIFF
--- a/assets/cms/js/alert.js
+++ b/assets/cms/js/alert.js
@@ -98,13 +98,14 @@ class ConcreteAlert {
             icon: 'check-circle',
             title: false,
             message: false,
+            plainTextMessage: false,
             delay: 2000,
             callback: () => {}
         }, defaults)
 
         const notifyOptions = {
             text: options.message,
-            textTrusted: true,
+            textTrusted: !options.plainTextMessage,
             icon: 'fas fa-' + options.icon,
             type: options.type,
             delay: options.delay,


### PR DESCRIPTION
This "unsafe" data may contain HTML, and we may want to escape it.

By default we keep the previous behavior (that is, display messages as if they were in HTML format).