### PR TITLE
Configure the linter so that it accepts ES2020 features

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,8 @@
 ---
 extends:
   - plugin:vue/base
+parserOptions:
+  ecmaVersion: 2020
 rules:
   indent:
   - error


### PR DESCRIPTION
Consider this code (it's [valid es2020](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining)):

```JavaScript
parseInt(this.selectedGroup?.gID) || 0
```

The linter doesn't like this syntax: it fails with this error

```
Parsing error: Unexpected token .
```

What about configuring the linter so that it accepts the es2020 features?

PS: when we build the assets, it gets transpiled to this:

```JavaScript
parseInt(null===(n=this.selectedGroup)||void 0===n?void 0:n.gID)||0
```

which, in a less compressed version, can be read as

```JavaScript
parseInt(this.selectedGroup === null || this.selectedGroup === undefined ? undefined : this.selectedGroup.gID) || 0
```

So, it's compatible with old browsers (I've just tested it).
