### PR TITLE
Avoid double tooltip initialization

### DIFF
--- a/assets/cms/js/toolbar.js
+++ b/assets/cms/js/toolbar.js
@@ -62,7 +62,7 @@
 
         const tooltipTriggerList = [].slice.call(document.querySelectorAll('.launch-tooltip'))
         tooltipTriggerList.map(function (tooltipTriggerEl) {
-            return new bootstrap.Tooltip(tooltipTriggerEl, {
+            return bootstrap.Tooltip.getInstance(tooltipTriggerEl) || new bootstrap.Tooltip(tooltipTriggerEl, {
                 container: '#ccm-tooltip-holder',
                 delay: {
                     show: 500,


### PR DESCRIPTION
The elements in the dashboard pages marked with the `launch-tooltip` CSS class are configured more than once: [here](https://github.com/concretecms/concretecms/blob/369a7050380dfb01e335ada3bb6e160800554835/build/assets/themes/dashboard/js/main.js#L129-L134) and [here](https://github.com/concretecms/bedrock/blob/572c49957d638d55ebebc7d8ed79d9c6d86a88e9/assets/cms/js/toolbar.js#L63-L72).

The first time, bootstrap removed the `title` attribute, storing in in the tooltip configuration.
The second time, bootstrap doesn't fine the `title` attribute, so the tooltip won't be displayed.

The solution? Avoid double initialization of tooltips.

See also https://github.com/concretecms/concretecms/pull/10988
Fix https://github.com/concretecms/concretecms/issues/10944