### PR TITLE
Bugfix - state province select hasn't got an default value

### DIFF
--- a/assets/bedrock/js/frontend/locations/country-data-link.js
+++ b/assets/bedrock/js/frontend/locations/country-data-link.js
@@ -185,7 +185,7 @@ Link.prototype = {
                         .val(spCode)
                         .text(name)
 
-                    if (spCode === selectedStateprovince) {
+                    if (spCode == selectedStateprovince) {
                         $o.attr('selected', 'selected')
                     }
                     me.$stateprovinceSelect.append($o)


### PR DESCRIPTION
Because of different variable types `$o.attr('selected', 'selected')` is never called 