### PR TITLE
Fix fancytree multiselect level issue

### DIFF
--- a/assets/cms/js/tree.js
+++ b/assets/cms/js/tree.js
@@ -223,7 +223,7 @@ ConcreteTree.prototype = {
                 if (options.ajaxData.selected) {
                     //since the expand options is triggered we can asume that there are children.
                     data.node.children.forEach(function(nodeChild){
-                        if (options.ajaxData.selected.includes(nodeChild.key)) {
+                        if (options.ajaxData.selected.includes(parseInt(nodeChild.key))) {
                             nodeChild.setSelected(true);
                         }
                     });
@@ -232,7 +232,7 @@ ConcreteTree.prototype = {
             collapse: function(event, data) {
                 //loop over child nodes and check if node is still selected. If not remove it from the 'options.ajaxData.selected' array.
                 data.node.children.forEach(function(nodeChild) {
-                    if (options.ajaxData.selected.includes(nodeChild.key) && !nodeChild.isSelected()) {
+                    if (options.ajaxData.selected.includes(parseInt(nodeChild.key)) && !nodeChild.isSelected()) {
                         delete options.ajaxData.selected.splice(options.ajaxData.selected.indexOf(nodeChild.key), 1);
                     }
                 });

--- a/assets/cms/js/tree.js
+++ b/assets/cms/js/tree.js
@@ -224,7 +224,7 @@ ConcreteTree.prototype = {
                     //since the expand options is triggered we can asume that there are children.
                     data.node.children.forEach(function(nodeChild){
                         if (options.ajaxData.selected.includes(nodeChild.key)) {
-                            nodeChild.setSelected(!0);
+                            nodeChild.setSelected(true);
                         }
                     });
                 }

--- a/assets/cms/js/tree.js
+++ b/assets/cms/js/tree.js
@@ -222,20 +222,20 @@ ConcreteTree.prototype = {
                 //only if 'selected' array is available execute code.
                 if (options.ajaxData.selected) {
                     //since the expand options is triggered we can asume that there are children.
-                    data.node.children.forEach(function(nodeChild){
+                    data.node.children.forEach(function(nodeChild) {
                         if (options.ajaxData.selected.includes(parseInt(nodeChild.key))) {
-                            nodeChild.setSelected(true);
+                            nodeChild.setSelected(true)
                         }
-                    });
+                    })
                 }
             },
             collapse: function(event, data) {
                 //loop over child nodes and check if node is still selected. If not remove it from the 'options.ajaxData.selected' array.
                 data.node.children.forEach(function(nodeChild) {
                     if (options.ajaxData.selected.includes(parseInt(nodeChild.key)) && !nodeChild.isSelected()) {
-                        delete options.ajaxData.selected.splice(options.ajaxData.selected.indexOf(nodeChild.key), 1);
+                        delete options.ajaxData.selected.splice(options.ajaxData.selected.indexOf(nodeChild.key), 1)
                     }
-                });
+                })
             },
             dnd: {
                 preventRecursiveMoves: true, // Prevent dropping nodes on own descendants,

--- a/assets/cms/js/tree.js
+++ b/assets/cms/js/tree.js
@@ -218,7 +218,17 @@ ConcreteTree.prototype = {
 
                 return true
             },
-
+            expand: function(event, data) {
+                //only if 'selected' array is available execute code.
+                if (options.ajaxData.selected) {
+                    //since the expand options is triggered we can asume that there are children.
+                    data.node.children.forEach(function(nodeChild){
+                        if (options.ajaxData.selected.includes(nodeChild.key)) {
+                            nodeChild.setSelected(!0);
+                        }
+                    });
+                }
+            },
             dnd: {
                 preventRecursiveMoves: true, // Prevent dropping nodes on own descendants,
                 focusOnClick: true,

--- a/assets/cms/js/tree.js
+++ b/assets/cms/js/tree.js
@@ -229,6 +229,14 @@ ConcreteTree.prototype = {
                     });
                 }
             },
+            collapse: function(event, data) {
+                //loop over child nodes and check if node is still selected. If not remove it from the 'options.ajaxData.selected' array.
+                data.node.children.forEach(function(nodeChild) {
+                    if (options.ajaxData.selected.includes(nodeChild.key) && !nodeChild.isSelected()) {
+                        delete options.ajaxData.selected.splice(options.ajaxData.selected.indexOf(nodeChild.key), 1);
+                    }
+                });
+            },
             dnd: {
                 preventRecursiveMoves: true, // Prevent dropping nodes on own descendants,
                 focusOnClick: true,


### PR DESCRIPTION
Nodes more than two levels deep do not get preselected on load even though they are present on the ajaxData object.
By checking the childNodes on expanding a node we can select the nodes afterwards. Added the collapse callback because unchecking nodes kept preselecting the nodes again due to the ajaxData.selected array. By removing unchecked key from the array this issue is also resolved.