### PR TITLE
Use $ccm-toolbar-height variable to represent the CCM Toolbar height

### DIFF
--- a/assets/cms/scss/_intelligent-search.scss
+++ b/assets/cms/scss/_intelligent-search.scss
@@ -11,7 +11,7 @@ div#ccm-intelligent-search-results {
   position: fixed;
   right: 120px;
   text-align: left;
-  top: 48px;
+  top: $ccm-toolbar-height;
   width: 251px;
   z-index: $index-level-intelligent-search;
 

--- a/assets/cms/scss/_toolbar.scss
+++ b/assets/cms/scss/_toolbar.scss
@@ -2,7 +2,7 @@
 div#ccm-toolbar {
   background-color: $gray-100;
   border-bottom: 1px solid $gray-200;
-  height: 48px;
+  height: $ccm-toolbar-height;
   left: 0;
   position: fixed;
   top: 0;
@@ -386,7 +386,7 @@ ul.ccm-mobile-menu {
   overflow-y: scroll;
   padding: 15px 0;
   position: fixed;
-  top: 48px;
+  top: $ccm-toolbar-height;
   width: 100%;
   z-index: $index-level-main-bar;
 
@@ -514,6 +514,6 @@ html.ccm-toolbar-visible {
   .ccm-page {
     // This used to be dynamically included in the theme. Now we're moving it here.
     // The purpose of this code is to push the content of the page down if the toolbar appears at the top.
-    margin-top: 48px;
+    margin-top: $ccm-toolbar-height;
   }
 }

--- a/assets/cms/scss/_variables.scss
+++ b/assets/cms/scss/_variables.scss
@@ -360,3 +360,5 @@ $help-tour-position-color: #fff;
 
 /* Form Group */
 $form-group-margin-bottom: 1.5rem;
+
+$ccm-toolbar-height: 48px;

--- a/assets/cms/scss/panels/_shared.scss
+++ b/assets/cms/scss/panels/_shared.scss
@@ -138,7 +138,7 @@ div.ccm-panel-left {
 div.ccm-panel-content {
   bottom: 0;
   left: 0;
-  margin-top: 48px;
+  margin-top: $ccm-toolbar-height;
   overflow: auto;
   padding: 0;
   position: absolute;


### PR DESCRIPTION
Theme developers may need to use the height of the `ccm-toolbar` element: what about introducing a new variable instead of manually using `48px`?
