### PR TITLE
Preserve new lines in tooltips

### DIFF
--- a/assets/cms/scss/_tooltips.scss
+++ b/assets/cms/scss/_tooltips.scss
@@ -24,6 +24,9 @@ div#ccm-tooltip-holder {
   .popover {
     z-index: $index-level-tooltip-holder;
   }
+  .tooltip-inner {
+    white-space: pre-wrap;
+  }
 }
 
 div.tooltip-inner {

--- a/assets/cms/scss/_tooltips.scss
+++ b/assets/cms/scss/_tooltips.scss
@@ -24,6 +24,7 @@ div#ccm-tooltip-holder {
   .popover {
     z-index: $index-level-tooltip-holder;
   }
+  
   .tooltip-inner {
     white-space: pre-wrap;
   }


### PR DESCRIPTION
For example, this would turn

![immagine](https://github.com/concretecms/bedrock/assets/928116/03579d50-215f-47f3-b3b7-f31eaeeec4cc)

into

![immagine](https://github.com/concretecms/bedrock/assets/928116/4cd6938d-ac2e-4a9d-89ac-37377caab8e2)

if tooltips contain new line characters.