### PR TITLE
Add check prompt when content block cancel used

### DIFF
--- a/assets/ckeditor/js/concrete/inline.js
+++ b/assets/ckeditor/js/concrete/inline.js
@@ -15,8 +15,16 @@ CKEDITOR.plugins.add('concreteinline', {
 
         editor.addCommand('c5cancel', {
             exec: function (editor) {
-                ConcreteEvent.fire('EditModeExitInline')
-                editor.destroy()
+                if (editor.checkDirty()) {
+                    ConcreteAlert.confirm(ccmi18n_editor.cancelPrompt, function () {
+                        $.fn.dialog.closeTop();
+                        ConcreteEvent.fire('EditModeExitInline')
+                        editor.destroy()
+                    }, 'btn-danger', ccmi18n_editor.cancelPromptButton);
+                } else {
+                    ConcreteEvent.fire('EditModeExitInline')
+                    editor.destroy()
+                }
             }
         })
 


### PR DESCRIPTION
This change adds a confirmation prompt when the cancel button is used on the inline editor toolbar on a Content block, _and_ a change has been made to the contents  (uses the checkDirty function of CKEditor). If no change has been made, the cancel works immediately.

We realised lately that the cancel button is _right_ next to the save button, and it's very easy to mis-click and hit it, without any protection.  This means that users can make a large series of changes to a content block, and then accidentally lose it all, with no way to recover.  Much swearing can occur.

![Screen Shot 2023-09-05 at 1 14 52 pm](https://github.com/concretecms/bedrock/assets/1079600/c5c073ae-7f9f-48aa-87a6-abd5d8492143)
